### PR TITLE
fix: adjust base message payload to not include empty data object

### DIFF
--- a/src/messages/message.js
+++ b/src/messages/message.js
@@ -3,7 +3,5 @@ export default class Message {
   constructor(type) {
     /** @type {string} */
     this.type = type;
-    /** @type {Object} */
-    this.data = {};
   }
 }


### PR DESCRIPTION
The base Message class includes an empty data object that throws off the json parsers in the Android app. This removes it, since it's not actually used for anything (subclass events continue to provide a data object).