### PR TITLE
docs: clarify "Alpha" status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,6 @@
 
 A javascript module to interface between a Banno Plugin webview and the host application.
 
-## Host events
-
-Host applications can send the web-app the following events:
-
-`history-back` - 'back' navigation occured.
-
-`history-forward` - 'forward' navigation occured.
-
-## App events
-
-The web app can dispatch the following events up to the host application:
-
-`click-link` - `{href: 'https://target', external:boolean}` - A routeable link was clicked within the app. If external is true, link will be opened in a new tab window in Banno Online or an external browser on Banno Mobile.
-
-`ping` - Occurs periodically to prevent the host app from timing out due to inactivity.
-
-`ready` - The web app has finished loading it's assets and initial data. Used for hiding native loading indicators.
-
-`request-close` - The web app would like to be closed. Not valid in all browsing contexts.
-
-`request-resize` - The web app has been resized and is reporting it's new height.
-
-`request-sync` - The web app needs the host to perform a sync.
-
 ## Routing
 
 The app contains a small router to automatically convert html `<a>` tag clicks into app `click-link` events.
@@ -55,3 +31,27 @@ An anchor with a `target="_blank"` attribute will be intercepted and converted i
 ```html
 <a href="/external-link" target="_blank">App external link</a>
 ```
+
+## Host events
+
+Host applications can send the web-app the following events:
+
+`history-back` - 'back' navigation occured.
+
+`history-forward` - 'forward' navigation occured.
+
+## App events
+
+The web app can dispatch the following events up to the host application:
+
+`click-link` - `{href: 'https://target', external:boolean}` - A routeable link was clicked within the app. If external is true, link will be opened in a new tab window in Banno Online or an external browser on Banno Mobile.
+
+`ping` - Occurs periodically to prevent the host app from timing out due to inactivity.
+
+`ready` - The web app has finished loading it's assets and initial data. Used for hiding native loading indicators.
+
+`request-close` - The web app would like to be closed. Not valid in all browsing contexts.
+
+`request-resize` - The web app has been resized and is reporting it's new height.
+
+`request-sync` - The web app needs the host to perform a sync.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An anchor with a `target="_blank"` attribute will be intercepted and converted i
 <a href="/external-link" target="_blank">App external link</a>
 ```
 
-## Host events
+## Host events (Alpha)
 
 Host applications can send the web-app the following events:
 
@@ -40,7 +40,7 @@ Host applications can send the web-app the following events:
 
 `history-forward` - 'forward' navigation occured.
 
-## App events
+## App events (Alpha)
 
 The web app can dispatch the following events up to the host application:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 A javascript module to interface between a Banno Plugin webview and the host application.
 
+## NOTE:
+
+Some of this module's features are in an [Alpha](https://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha) phase of development.
+
+An `(Alpha)` annotation by a feature name means that the feature has not been verified to function across all of Banno's consumer apps:
+- `Banno Online`
+- `Banno Mobile (Android)`
+- `Banno Mobile (iOS)`
+
 ## Routing
 
 The app contains a small router to automatically convert html `<a>` tag clicks into app `click-link` events.


### PR DESCRIPTION
# Summary

This PR updates the README in the following ways, for clarity:

- Re-arrange README sections - https://github.com/Banno/banno-plugin-framework-bridge/commit/81238911fecc6ffee0613e3fec52f613b3c36b30
- Annotate "Alpha" features - https://github.com/Banno/banno-plugin-framework-bridge/commit/b051a4edca9c31e03896c8cee436c2e7edf68e31
- Add explanation of "Alpha" phase - https://github.com/Banno/banno-plugin-framework-bridge/commit/23233a486e3b40316d77df4ac1380f6b4601b1a7