### PR TITLE
feat: added request-refresh message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import Message from './messages/message.js';
 const MESSAGES = {
   REQUEST_CLOSE: 'request-close',
   REQUEST_SYNC: 'request-sync',
+  REQUEST_REFRESH: 'request-refresh',
   PING: 'ping',
   READY: 'ready',
 };
@@ -23,6 +24,13 @@ function requestClose() {
  */
 function requestSync() {
   postUniversalMessage(new Message(MESSAGES.REQUEST_SYNC));
+}
+
+/**
+ * request that the host perform a refresh of the component
+ */
+function requestRefresh() {
+  postUniversalMessage(new Message(MESSAGES.REQUEST_REFRESH));
 }
 
 /**


### PR DESCRIPTION
The request-refresh message is a new message that mobile clients accept. When called the host will call a refresh on the component which made the request. This message was created so that SSOs and PowerOns in dashboard cards could be updated without the user having to close or leave the dashboard. This message is already available in the Android app and will be released in v3.11 of the iOS app.

At this time this message does not exist in banno-online.